### PR TITLE
chore: keep codecov upload path active

### DIFF
--- a/.github/workflows/codecov-analytics.yml
+++ b/.github/workflows/codecov-analytics.yml
@@ -26,16 +26,19 @@ jobs:
           node-version: '20'
 
       - name: Backend coverage
+        continue-on-error: true
         run: |
           mkdir -p coverage
           python -m pip install --upgrade pip
           python -m pip install -r backend/requirements.txt pytest pytest-cov
           python -m pytest backend --cov=backend --cov-report=xml:backend/coverage.xml
       - name: Frontend coverage
+        continue-on-error: true
         run: |
           npm --prefix frontend/webcoder_ui ci
           npm --prefix frontend/webcoder_ui test -- --coverage --watch=false
       - name: Upload coverage to Codecov
+        if: ${{ always() }}
         uses: codecov/codecov-action@v5
         with:
           files: backend/coverage.xml,frontend/webcoder_ui/coverage/lcov.info


### PR DESCRIPTION
Follow-up CI wiring patch to keep Codecov upload execution active even when coverage-producing steps fail early.\n\n- marks coverage-producing steps as continue-on-error\n- runs upload step with if: always\n\nCo-authored-by: Codex <noreply@openai.com>