### PR TITLE
chore: ruff F401/F841 + workflow least-privilege (16 CodeQL findings cleared)

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: ["main", "master"]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/django_ci.yml
+++ b/.github/workflows/django_ci.yml
@@ -10,6 +10,9 @@ on:
     paths:
       - 'backend/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/backend/problems/serializers.py
+++ b/backend/problems/serializers.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.contrib.auth import get_user_model # Import get_user_model
 from rest_framework import serializers
 from .models import Tag, Problem, TestCase

--- a/backend/problems/tests.py
+++ b/backend/problems/tests.py
@@ -1,3 +1,2 @@
-from django.test import TestCase
 
 # Create your tests here.

--- a/backend/problems/views.py
+++ b/backend/problems/views.py
@@ -5,7 +5,7 @@ from rest_framework.response import Response
 from .models import Tag, Problem, TestCase
 from .serializers import TagSerializer, ProblemSerializer, ProblemDetailSerializer, TestCaseSerializer
 from users.models import User
-from users.permissions import IsAdminUser, IsProblemCreator, IsProblemVerifier, ProblemObjectPermissions
+from users.permissions import IsProblemCreator, IsProblemVerifier, ProblemObjectPermissions
 
 
 class TagViewSet(viewsets.ModelViewSet):

--- a/backend/submissions/judge_utils/comparison.py
+++ b/backend/submissions/judge_utils/comparison.py
@@ -1,4 +1,3 @@
-import pathlib # Not strictly needed by this function but good for consistency if other utils use it
 from problems.models import Problem # For Problem.ComparisonMode
 
 def compare_outputs(

--- a/backend/submissions/judge_utils/execution.py
+++ b/backend/submissions/judge_utils/execution.py
@@ -1,6 +1,5 @@
 import pathlib
 import subprocess
-import random 
 from django.conf import settings # Import Django settings
 from ..models import Submission 
 

--- a/backend/submissions/serializers.py
+++ b/backend/submissions/serializers.py
@@ -1,7 +1,7 @@
 from rest_framework import serializers
 from .models import Submission, SubmissionTestResult # Import SubmissionTestResult
 from users.serializers import UserSerializer 
-from problems.models import Problem, TestCase # Import TestCase for SubmissionTestResultSerializer
+from problems.models import Problem # Import TestCase for SubmissionTestResultSerializer
 
 class SubmissionTestResultSerializer(serializers.ModelSerializer):
     # test_case_id = serializers.ReadOnlyField(source='test_case.id') # Simple ID

--- a/backend/submissions/tasks.py
+++ b/backend/submissions/tasks.py
@@ -2,12 +2,8 @@ from celery import shared_task
 from django.db import transaction
 from .models import Submission, SubmissionTestResult # Import SubmissionTestResult
 from problems.models import Problem, TestCase
-import time
-import random
-import subprocess
 import tempfile
 import pathlib
-import shutil
 
 from .judge_utils.comparison import compare_outputs
 from .judge_utils.compilation import compile_code_in_sandbox

--- a/backend/submissions/tests.py
+++ b/backend/submissions/tests.py
@@ -1,3 +1,2 @@
-from django.test import TestCase
 
 # Create your tests here.

--- a/backend/users/adapters.py
+++ b/backend/users/adapters.py
@@ -1,7 +1,6 @@
 from allauth.account.adapter import DefaultAccountAdapter
 from allauth.socialaccount.adapter import DefaultSocialAccountAdapter
 from django.http import HttpResponseRedirect
-from django.urls import reverse
 
 class CustomAccountAdapter(DefaultAccountAdapter):
     def get_login_redirect_url(self, request):

--- a/backend/users/urls.py
+++ b/backend/users/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path, include
 from rest_framework.routers import DefaultRouter
-from .views import UserRegistrationView, PasswordChangeView, UserMeView, AdminUserViewSet, GoogleLogin, GithubLogin, AdminStatsView, UserViewSet
+from .views import UserRegistrationView, PasswordChangeView, UserMeView, AdminUserViewSet, AdminStatsView, UserViewSet
 
 app_name = "users"
 

--- a/backend/users/views.py
+++ b/backend/users/views.py
@@ -40,7 +40,6 @@ class PasswordChangeView(generics.GenericAPIView):
     permission_classes = [permissions.IsAuthenticated]
 
     def post(self, request, *args, **kwargs):
-        user = request.user
         serializer = self.get_serializer(data=request.data, context={'request': request})
         if serializer.is_valid(raise_exception=True):
             serializer.save()


### PR DESCRIPTION
## **User description**
## Quality-Zero-Platform: leveraged drive-to-zero

Two safe, high-leverage, single-rule CodeQL transforms. **No behavior change.**
Every edit is dead-code removal or static CI hardening; no logic was modified.

### Plays applied

**1. Python dead-code autofix (`ruff` single-rule transform) — 14 CodeQL alerts**
- `py/unused-import` (13 alerts / 14 import names): `ruff check backend --exclude venv --select F401 --fix`. Removes genuinely-dead imports across serializers, views, tasks, tests, urls, adapters. `users/urls.py`'s two unused names (`GoogleLogin`, `GithubLogin`) count as one CodeQL alert.
- `py/unused-local-variable` (1 alert): removed the `user = request.user` dead store in `PasswordChangeView.post` — pure RHS, never read, auth already enforced by the `IsAuthenticated` permission class. (Done manually; ruff classifies the F841 fix as "unsafe" and I declined `--unsafe-fixes`.)

**2. CI least-privilege (`actions/missing-workflow-permissions`) — 2 CodeQL alerts**
- Added top-level `permissions: contents: read` to `django.yml` and `django_ci.yml`. Both are pure test/lint runners (checkout → setup-python → pip install → compileall/flake8); neither pushes, comments, or uploads, so read-only is correct least privilege.

**Total: 16 CodeQL alerts cleared** (14 Python + 2 Actions).

### Verification
- `ruff check backend --exclude venv --select F401` → **All checks passed**
- `python -m compileall` → **clean** on all 11 changed Python files
- `python -c "import yaml; yaml.safe_load(...)"` → both workflows parse with the new `permissions` block
- ruff 0.15.12; Python 3.14. Full `pytest` not run (pinned Django/deps don't install on 3.14 in this sandbox) — dead-import/dead-store removal + ruff-clean + compileall is sufficient behavior-preserving evidence for these no-build-needed plays.

### Deliberately NOT touched (residual / needs-care)
- **`backend/venv/` (33 CodeQL alerts)** — left entirely to the open venv-purge **PR #78**; not re-touched.
- **15 path-injection (9 py + 6 js) + 1 partial-ssrf + js/user-controlled-bypass** — security fixes are not mechanical/uniform; need per-site review.
- **2 `py/multiple-definition`** (redefinition tracing = judgment), **5 `py/commented-out-code`** (deliberate developer-reference scaffolding), **2 `.tsx` js/unused-local** (need the frontend `npm` toolchain) — left for a separate, scoped pass.
- The leaked/operator-rotated secret and `secrets:S6687`/`python:S2068`/`python:S6437` — untouched.

### Dependabot
No config change. `.github/dependabot.yml` already has optimal grouped (patch/minor) updates per ecosystem with major-version ignores, and security updates are firing correctly as individual + grouped PRs (e.g. #48, #23, #22, #76, #59). The 104 security alerts collapse via those existing Dependabot PRs — an operator merge decision, out of scope here.

Part of the QZP drive-to-zero campaign. Reviewer merges; no auto-merge.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed dead Python code with `ruff` F401/F841 and set read-only workflow permissions to enforce least privilege. No behavior change; clears 16 CodeQL alerts across backend and CI.

<sup>Written for commit 407cce56c5d722d1cb33abe19381fa62b9f386fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Prekzursil/WebCoder/pull/79?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


___

## **CodeAnt-AI Description**
Clean up unused code and restrict CI access

### What Changed
- Removed unused imports and dead local variables from backend code without changing app behavior
- Removed an unused test import placeholder from two test files
- Dropped unused login imports and an unused redirect import
- Limited the GitHub Actions workflows to read-only repository access

### Impact
`✅ Fewer static analysis warnings`
`✅ Lower workflow permissions`
`✅ No change to app behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
