### PR TITLE
ci: exclude vendored/build-time tooling from CodeQL scanning

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,23 @@
+name: "webcoder CodeQL config"
+
+# Exclude vendored / generated / build-time tooling from CodeQL analysis.
+#
+# Rationale:
+#   * backend/venv               - generated Python virtualenv (third-party
+#                                  packages, e.g. Django REST Framework static
+#                                  JS). Already git-ignored and purged from VCS
+#                                  in #78; excluded defensively so a stray local
+#                                  venv can never re-pollute the scan.
+#   * frontend/webcoder_ui/config
+#   * frontend/webcoder_ui/scripts
+#                                - Create React App (react-scripts) *ejected*
+#                                  boilerplate. These are build-time Node tools
+#                                  whose file paths come from developer/CI env
+#                                  vars (NODE_ENV, SSL_CRT_FILE, .env files),
+#                                  not from attacker-reachable input. Treating
+#                                  them as application source produces
+#                                  build-tooling false positives.
+paths-ignore:
+  - backend/venv
+  - frontend/webcoder_ui/config
+  - frontend/webcoder_ui/scripts

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,7 +22,7 @@ jobs:
       actions: read
       contents: read
       security-events: write
-    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-codeql.yml@fbb2255753788b93cc79ec917c764d0fc4f52146
+    uses: Prekzursil/quality-zero-platform/.github/workflows/reusable-codeql.yml@b95033002271d49cf6526e19baba506fd2419c07
     with:
       repo_slug: ${{ github.repository }}
       event_name: ${{ github.event_name }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,3 +29,4 @@ jobs:
       sha: ${{ github.event.pull_request.head.sha || github.sha }}
       platform_repository: Prekzursil/quality-zero-platform
       platform_ref: main
+      codeql_config_file: ./.github/codeql/codeql-config.yml


### PR DESCRIPTION
## What
Wires the QZP reusable CodeQL workflow's `codeql_config_file` input to a new `.github/codeql/codeql-config.yml` that `paths-ignore`s generated/vendored/build-time code.

## Why
The active CodeQL series should never treat vendored or ejected build tooling as application source:
- `backend/venv` — generated Python virtualenv (DRF static JS etc.); already git-ignored and purged from VCS in #78. Defensive so a stray local venv cannot re-pollute scans.
- `frontend/webcoder_ui/config` & `frontend/webcoder_ui/scripts` — Create React App (react-scripts) **ejected** boilerplate; file paths derive from developer/CI env (NODE_ENV, SSL_CRT_FILE, .env), not attacker-reachable input.

## Context
Implements the 'exclude vendored from scanning, don't edit it' remediation for the remaining build-tooling/vendored CodeQL findings. The 20 historical open alerts belong to a **retired repo-local CodeQL series** (frozen at 73c33c8f, 2026-03-30) that the current QZP series cannot auto-close; those are being dismissed separately with per-alert justification (removed code / already-remediated workflow permissions / CRA build-tooling false positives).

## Test plan
- [ ] CodeQL workflow runs green with the config file applied
- [ ] No new alerts introduced